### PR TITLE
Add no_mime_magic option.

### DIFF
--- a/lib/ruby-s3cmd/s3cmd.rb
+++ b/lib/ruby-s3cmd/s3cmd.rb
@@ -156,6 +156,11 @@
     # --mime-type option
     #
     attr_accessor :guess_mime_type
+    
+    #
+    # Don't use mime magic when guessing MIME-type.
+    #
+    attr_accessor :no_mime_magic
 
     #
     # Add  a  given  HTTP  header  to the upload request. Can be used multiple times with different header


### PR DESCRIPTION
no_mime_magic was introduced in s3tools/s3cmd#218 and is a useful option to be able to access.